### PR TITLE
Refactor `/login` endpoint to only accept `POST` requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -200,7 +200,7 @@ def create_app(config_name):
         else:
             return make_response(jsonify(error="User not found."), 404)
 
-    @app.route('/login')
+    @app.route('/login', methods=['POST'])
     def login():
         email = str(request.json.get('email', ''))
         password = str(request.json.get('password', ''))

--- a/test_user_auth.py
+++ b/test_user_auth.py
@@ -18,7 +18,7 @@ class UserTestCase(unittest.TestCase):
 
     def test_user_authentication(self):
         body = {"email": "rhantak@example.com","password": "password"}
-        res = self.client().get('/login', json=self.user)
+        res = self.client().post('/login', json=self.user)
         data = json.loads(res.get_data(as_text=True))
 
         self.assertEqual(res.status_code, 303)


### PR DESCRIPTION
### What's this PR do?
- Corrects bug by refactoring `/login` endpoint to only accept `POST` requests instead of `GET` requests

### Where should the reviewer start?
- `POST /login` route in `/app/__init__.py`

### How should this be manually tested?
- Using Postman, send requests to `POST /login` with body formatted as such:
```
{
   email: "valid user email goes here",
   password: "valid user password goes here"
}
```
closes #48 